### PR TITLE
Add path:dig command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,31 +24,40 @@ In Creative mode, you can place as many blocks of any type as you want, with no 
 
 #### Basic
 
-`path:basic <distance> [with lights]` (aliased as `pb`) where \<distance\> is the number of blocks to place, and [with lights] is an optional boolean `true|false` whether to place a light every N<sup>\*</sup> number of blocks.
+`path:basic <distance> [with lights]` (_aliased as `pb`_) where \<distance\> is the number of blocks to place, and [with lights] is an optional boolean `true|false` whether to place a light every N<sup>\*</sup> number of blocks.
 
 For example: `path:basic 25 true` to create a path 25 blocks long with lights, or `path:basic 25` where [with lights] defaults to false for no lights.
 
 #### Tracks
 
-`path:tracks <distance> [with power] [with lights]` (aliased as `pt`) where \<distance\> is the number of blocks to place, and [with power] is an optional boolean `true|false` whether to place a powered rail every N<sup>\*</sup> number of blocks. [with lights] is another optional boolean whether to place a light every N<sup>\*</sup> number of blocks.
+`path:tracks <distance> [with power] [with lights]` (_aliased as `pt`_) where \<distance\> is the number of blocks to place, and [with power] is an optional boolean `true|false` whether to place a powered rail every N<sup>\*</sup> number of blocks. [with lights] is another optional boolean whether to place a light every N<sup>\*</sup> number of blocks.
 
 <sup>\*</sup> _N is configurable in `/plugins/Pathinator/config.yml`_
 
 #### Custom
 
-`path:custom <distance> <width> <height> [path material] [clearance material]` (aliased as `pc`) where **\<distance\>** **\<width\>** and **\<height\>** are required and **[path material]** and **[clearance material]** are optional. If no **[path material]** is specified Pathinator will detect the pattern of blocks the player is currently standing on for the path. For example: if you create a path 3 blocks wide Pathinator will detect the block under the player and one block to the left and right and keep that same pattern for the entire distance requested.
+`path:custom <distance> <width> <height> [path material] [clearance material]` (_aliased as `pc`_) where **\<distance\>** **\<width\>** and **\<height\>** are required and **[path material]** and **[clearance material]** are optional. If no **[path material]** is specified Pathinator will detect the pattern of blocks the player is currently standing on for the path. For example: if you create a path 3 blocks wide Pathinator will detect the block under the player and one block to the left and right and keep that same pattern for the entire distance requested.
 
 Additionally, you can specify what material to use to fill the 'air' space above the path (clearance material). This allows you to easily create 3 dimensional structures out of any material!
 
 #### Follow
 
-`path:follow <start|stop> [radius] [path material]` (aliased as `pf`) where **[radius]** is a number between 0 and 5, and **[path material]** is any solid block. **NOTE you must run `path:follow stop` to tell Pathinator to stop creating a path wherever you walk.**
+`path:follow <start|stop> [radius] [path material]` (_aliased as `pf`_) where **[radius]** is a number between 0 and 5, and **[path material]** is any solid block. **NOTE you must run `path:follow stop` to tell Pathinator to stop creating a path wherever you walk.**
 
 For example, `path:follow start` will start following using the default radius and whatever block you are currently standing on. `path:follow start 2 minecraft:oak_planks` will create a wide path with OAK_PLANKS.
 
 The follow command only works in Creative mode at this time.
 
-## Examples
+#### Dig
+
+`path:dig <up|down|ahead|vup|vdown> [distance]` (_aliased as `pd`_) where \<distance\> is the number of blocks away from you to dig. `path:dig` does not place any blocks, it only removes them (_and adds to your inventory when in survival_).
+`up|down` will dig a stair step pattern either up or down with the default clearance height (set in config.yml).
+`vup|vdown` (vertical up | vertical down) will dig straight up or down starting from one block in front of where the player is standing.
+
+For example, `path:dig down 20` will dig a stair step pattern extending 20 blocks, starting from the block in front of the player. (1 block forward, and 1 block down)
+`path:dig vup 20` will dig straight up for 20 blocks starting from the block in front of the player.
+
+## GIF Examples
 
 <details> 
   <summary>/path:basic</summary>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.hidethemonkey</groupId>
     <artifactId>Pathinator</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
     <name>Pathinator</name>
 
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>3.0.3</version>
+            <version>3.1.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>

--- a/src/main/java/com/hidethemonkey/pathinator/Pathinator.java
+++ b/src/main/java/com/hidethemonkey/pathinator/Pathinator.java
@@ -32,6 +32,7 @@ import dev.jorel.commandapi.arguments.BlockStateArgument;
 import dev.jorel.commandapi.arguments.BooleanArgument;
 import dev.jorel.commandapi.arguments.IntegerArgument;
 import dev.jorel.commandapi.arguments.LiteralArgument;
+import dev.jorel.commandapi.arguments.StringArgument;
 import dev.jorel.commandapi.executors.PlayerCommandExecutor;
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -47,6 +48,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import com.hidethemonkey.pathinator.commands.BasicCommands;
 import com.hidethemonkey.pathinator.commands.CustomCommands;
+import com.hidethemonkey.pathinator.commands.DigCommands;
 import com.hidethemonkey.pathinator.commands.FollowCommands;
 import com.hidethemonkey.pathinator.commands.PathCommands;
 import com.hidethemonkey.pathinator.commands.TrackCommands;
@@ -155,6 +157,30 @@ public class Pathinator extends JavaPlugin {
                             .executesPlayer((PlayerCommandExecutor) follow::stopFollowing))
                     .register();
         }
+
+        DigCommands dig = new DigCommands(this);
+        new CommandTree(PathCommands.DIG).withAliases("pd")
+                .then(new StringArgument(
+                        PathCommands.UP)
+                        .then(new IntegerArgument(PathCommands.DISTANCE)
+                                .executesPlayer((PlayerCommandExecutor) dig::createPath)))
+                .then(new StringArgument(
+                        PathCommands.DOWN)
+                        .then(new IntegerArgument(PathCommands.DISTANCE)
+                                .executesPlayer((PlayerCommandExecutor) dig::createPath)))
+                .then(new StringArgument(
+                        PathCommands.AHEAD)
+                        .then(new IntegerArgument(PathCommands.DISTANCE)
+                                .executesPlayer((PlayerCommandExecutor) dig::createPath)))
+                .then(new StringArgument(
+                        PathCommands.VUP)
+                        .then(new IntegerArgument(PathCommands.DISTANCE)
+                                .executesPlayer((PlayerCommandExecutor) dig::createPath)))
+                .then(new StringArgument(
+                        PathCommands.VDOWN)
+                        .then(new IntegerArgument(PathCommands.DISTANCE)
+                                .executesPlayer((PlayerCommandExecutor) dig::createPath)))
+                .register();
     }
 
     /**

--- a/src/main/java/com/hidethemonkey/pathinator/commands/DigCommands.java
+++ b/src/main/java/com/hidethemonkey/pathinator/commands/DigCommands.java
@@ -1,0 +1,79 @@
+package com.hidethemonkey.pathinator.commands;
+
+import dev.jorel.commandapi.executors.CommandArguments;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.hidethemonkey.pathinator.Pathinator;
+import com.hidethemonkey.pathinator.helpers.BlockHelper;
+import com.hidethemonkey.pathinator.helpers.PlayerHelper;
+import com.hidethemonkey.pathinator.helpers.SegmentData;
+
+public class DigCommands extends PathCommands {
+
+    public DigCommands(Pathinator pathPlugin) {
+        super(pathPlugin);
+    }
+
+    @Override
+    public void createPath(CommandSender sender, CommandArguments args) {
+        Player player = (Player) sender;
+
+        // init some helpers
+        PlayerHelper playerHelper = new PlayerHelper(player, plugin);
+        BlockHelper blockHelper = new BlockHelper(plugin);
+
+        // Check if the player is in a supported game mode
+        if (!modeCheck(playerHelper)) {
+            return;
+        }
+
+        // Get the block under the player
+        Block targetBlock = findTargetBlock(blockHelper, playerHelper);
+        if (targetBlock == null) {
+            return;
+        }
+
+        BlockFace facing = player.getFacing();
+        Integer distance = getDistance(args);
+        Integer height = getHeight(args, config.getClearance() - 1);
+
+        Enum<?> digDirection = getDigDirection(args);
+
+        Location startingLocation = targetBlock.getLocation().clone().add(0, 1, 0);
+
+        if (digDirection == DigDirection.VUP || digDirection == DigDirection.VDOWN) {
+            startingLocation = blockHelper.adjustLocationForward(startingLocation, facing);
+            height = -1;
+        }
+
+        for (int i = 0; i < distance; i++) {
+            if (digDirection != DigDirection.VUP && digDirection != DigDirection.VDOWN) {
+                startingLocation = blockHelper.adjustLocationForward(startingLocation, facing);
+            }
+
+            if (digDirection == DigDirection.UP) {
+                startingLocation = startingLocation.add(0, 1, 0);
+            } else if (digDirection == DigDirection.DOWN) {
+                startingLocation = startingLocation.subtract(0, 1, 0);
+            } else if (digDirection == DigDirection.VUP && i > 0) {
+                startingLocation = startingLocation.add(0, 1, 0);
+            } else if (digDirection == DigDirection.VDOWN && i > 0) {
+                startingLocation = startingLocation.subtract(0, 1, 0);
+            }
+
+            SegmentData segmentData = new SegmentData();
+            segmentData.setWorld(player.getWorld());
+            segmentData.setBaseFacing(facing);
+            segmentData.setBaseLocation(startingLocation.clone());
+            segmentData.setClearance(height);
+
+            blockHelper.digBlocks(segmentData, i, playerHelper);
+        }
+    }
+
+}

--- a/src/main/java/com/hidethemonkey/pathinator/commands/PathCommands.java
+++ b/src/main/java/com/hidethemonkey/pathinator/commands/PathCommands.java
@@ -47,6 +47,7 @@ public abstract class PathCommands {
     public static final String CUSTOM = "path:custom";
     public static final String TRACKS = "path:tracks";
     public static final String FOLLOW = "path:follow";
+    public static final String DIG = "path:dig";
 
     // parameters
     public static final String DISTANCE = "distance";
@@ -59,9 +60,35 @@ public abstract class PathCommands {
     public static final String RADIUS = "radius";
     public static final String START = "start";
     public static final String STOP = "stop";
+    public static final String UP = "up";
+    public static final String DOWN = "down";
+    public static final String AHEAD = "ahead";
+    public static final String VUP = "vup";
+    public static final String VDOWN = "vdown";
 
     protected Pathinator plugin;
     protected PathinatorConfig config;
+
+    enum DigDirection {
+        UP,
+        DOWN,
+        AHEAD,
+        VUP,
+        VDOWN;
+    }
+
+    public Enum<?> getDigDirection(CommandArguments args) {
+        Object upDownDir = args.get(0);
+
+        if (upDownDir != null) {
+            try {
+                return DigDirection.valueOf(upDownDir.toString().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                // Do nothing
+            }
+        }
+        return DigDirection.AHEAD;
+    }
 
     /**
      * Constructor for PathCommands.


### PR DESCRIPTION
Adds new `path:dig` command to help excavate material without placing down a path.

Features include `up|down` to dig a stair step pattern (1 forward, and 1 up|down), `ahead` to dig straight ahead, and `vup|vdown` to dig straight up or down.

This update also includes respect for SILK_TOUCH, FORTUNE, and UNBREAKING when using tools in survival mode.