### PR TITLE
Update dependencies: move from Spigotmc to Papermc API.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.hidethemonkey</groupId>
     <artifactId>Pathinator</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <packaging>jar</packaging>
     <name>Pathinator</name>
 
@@ -19,26 +19,24 @@
     </properties>
 
     <repositories>
-        <!-- This adds the Spigot Maven repository to the build -->
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 
     <dependencies>
-        <!-- https://www.spigotmc.org/wiki/spigot-maven/ -->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://commandapi.jorel.dev/latest.html -->
         <dependency>
             <groupId>dev.jorel</groupId>
             <artifactId>commandapi-bukkit-shade</artifactId>
-            <version>9.5.3</version>
+            <version>9.7.0</version>
         </dependency>
         <!-- https://bstats.org/getting-started/include-metrics -->
         <dependency>
@@ -50,13 +48,18 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20240303</version>
+            <version>20250107</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.maven/maven-artifact -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>3.9.9</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.18.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/hidethemonkey/pathinator/Pathinator.java
+++ b/src/main/java/com/hidethemonkey/pathinator/Pathinator.java
@@ -54,7 +54,6 @@ import com.hidethemonkey.pathinator.commands.PathCommands;
 import com.hidethemonkey.pathinator.commands.TrackCommands;
 import com.hidethemonkey.pathinator.helpers.ConsoleHelper;
 import com.hidethemonkey.pathinator.helpers.FollowRegistry;
-import com.hidethemonkey.pathinator.helpers.StringHelper;
 import com.hidethemonkey.pathinator.helpers.VersionChecker;
 import com.hidethemonkey.pathinator.helpers.VersionData;
 import com.hidethemonkey.pathinator.listeners.PlayerMoveListener;
@@ -137,18 +136,16 @@ public class Pathinator extends JavaPlugin {
             getServer().getPluginManager().registerEvents(new PlayerMoveListener(this, followRegistry), this);
             FollowCommands follow = new FollowCommands(this, followRegistry);
             new CommandTree(PathCommands.FOLLOW).withAliases("pf")
-                    .then(new LiteralArgument(
-                            PathCommands.START)
-                            .then(new IntegerArgument(
+                    .thenNested(new LiteralArgument(PathCommands.START),
+                            new IntegerArgument(
                                     PathCommands.RADIUS,
-                                    PathinatorConfig.MIN_RADIUS, PathinatorConfig.MAX_RADIUS)
-                                    .then(new BlockStateArgument(PathCommands.PATH_MATERIAL)
-                                            .executesPlayer((PlayerCommandExecutor) follow::createPath))))
-                    .then(new LiteralArgument(
-                            PathCommands.START)
-                            .then(new IntegerArgument(PathCommands.RADIUS, PathinatorConfig.MIN_RADIUS,
+                                    PathinatorConfig.MIN_RADIUS, PathinatorConfig.MAX_RADIUS),
+                            new BlockStateArgument(PathCommands.PATH_MATERIAL)
+                                    .executesPlayer((PlayerCommandExecutor) follow::createPath))
+                    .thenNested(new LiteralArgument(PathCommands.START),
+                            new IntegerArgument(PathCommands.RADIUS, PathinatorConfig.MIN_RADIUS,
                                     PathinatorConfig.MAX_RADIUS)
-                                    .executesPlayer((PlayerCommandExecutor) follow::createPath)))
+                                    .executesPlayer((PlayerCommandExecutor) follow::createPath))
                     .then(new LiteralArgument(
                             PathCommands.START)
                             .executesPlayer((PlayerCommandExecutor) follow::createPath))
@@ -273,9 +270,9 @@ public class Pathinator extends JavaPlugin {
             return;
         }
         DefaultArtifactVersion latestVersion = new DefaultArtifactVersion(versionData.getVersion());
-        DefaultArtifactVersion currentVersion = new DefaultArtifactVersion(getDescription().getVersion());
+        DefaultArtifactVersion currentVersion = new DefaultArtifactVersion(getPluginMeta().getVersion());
         if (latestVersion.compareTo(currentVersion) > 0) {
-            ConsoleHelper.sendNewVersionNotice(versionData.getVersion(), getDescription().getVersion());
+            ConsoleHelper.sendNewVersionNotice(versionData.getVersion(), getPluginMeta().getVersion());
         }
     }
 
@@ -284,7 +281,7 @@ public class Pathinator extends JavaPlugin {
         public void onPlayerJoin(PlayerJoinEvent event) {
             getMetrics().addCustomChart(
                     new SimplePie("player_locale",
-                            () -> String.valueOf(StringHelper.formatLocale(event.getPlayer().getLocale()))));
+                            () -> String.valueOf(event.getPlayer().locale().toString())));
         }
     }
 

--- a/src/main/java/com/hidethemonkey/pathinator/PathinatorConfig.java
+++ b/src/main/java/com/hidethemonkey/pathinator/PathinatorConfig.java
@@ -210,7 +210,7 @@ public class PathinatorConfig {
         if (configVersion == null || configVersion.isBlank()) {
             configVersion = "unknown";
         }
-        String currentVersion = plugin.getDescription().getVersion();
+        String currentVersion = plugin.getPluginMeta().getVersion();
         if (!currentVersion.equals(configVersion)) {
             // backup current config
             File sourceFile = new File(plugin.getDataFolder(), file.getName());

--- a/src/main/java/com/hidethemonkey/pathinator/helpers/ConsoleHelper.java
+++ b/src/main/java/com/hidethemonkey/pathinator/helpers/ConsoleHelper.java
@@ -24,38 +24,54 @@
 
 package com.hidethemonkey.pathinator.helpers;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.ConsoleCommandSender;
 
 public class ConsoleHelper {
     private static final ConsoleCommandSender CONSOLE = Bukkit.getServer().getConsoleSender();
 
+    public static void logMessage(String message) {
+        CONSOLE.sendMessage("");
+        CONSOLE.sendMessage(Component.text(message, NamedTextColor.DARK_AQUA));
+        CONSOLE.sendMessage("");
+    }
+
     public static void sendNewVersionNotice(String newVersion, String currentVersion) {
         CONSOLE.sendMessage("");
-        CONSOLE.sendMessage(
-                ChatColor.DARK_AQUA + "************************************************************************");
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "* " + ChatColor.RESET + "A new version of " + ChatColor.BOLD
-                + "Pathinator" + ChatColor.RESET + " is available!");
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "*");
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "* " + ChatColor.RESET + "Current Version: " + currentVersion);
-        CONSOLE.sendMessage(
-                ChatColor.DARK_AQUA + "* " + ChatColor.RESET + ChatColor.BOLD + "New Version: " + newVersion);
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "*");
-        CONSOLE.sendMessage(
-                ChatColor.DARK_AQUA + "* " + ChatColor.RESET
-                        + "Please update to take advantage of the latest features and bug fixes.");
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "*");
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "* " + ChatColor.RESET + "Download from your preferred site:");
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "* " + ChatColor.RESET
-                + "     Hangar: https://hangar.papermc.io/HideTheMonkey/Pathinator");
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "* " + ChatColor.RESET
-                + "     Modrinth: https://modrinth.com/plugin/pathinator");
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "* " + ChatColor.RESET
-                + "     Spigot: https://www.spigotmc.org/resources/pathinator.118803");
-        CONSOLE.sendMessage(ChatColor.DARK_AQUA + "*");
-        CONSOLE.sendMessage(
-                ChatColor.DARK_AQUA + "************************************************************************");
+        CONSOLE.sendMessage(Component.text("************************************************************************",
+                NamedTextColor.DARK_AQUA));
+        CONSOLE.sendMessage(Component.text("* ",
+                NamedTextColor.DARK_AQUA).append(
+                        Component.text(
+                                "A new version of "))
+                .append(Component.text("Pathinator", Style.style(
+                        TextDecoration.BOLD)))
+                .append(Component.text(" is available!")));
+        CONSOLE.sendMessage(Component.text("*", NamedTextColor.DARK_AQUA));
+        CONSOLE.sendMessage(Component.text("* ", NamedTextColor.DARK_AQUA)
+                .append(Component.text("Current Version: " + currentVersion)));
+        CONSOLE.sendMessage(Component.text("* ", NamedTextColor.DARK_AQUA)
+                .append(Component.text("New Version: " + newVersion, Style.style(TextDecoration.BOLD))));
+        CONSOLE.sendMessage(Component.text("*", NamedTextColor.DARK_AQUA));
+        CONSOLE.sendMessage(Component.text("* ", NamedTextColor.DARK_AQUA)
+                .append(Component.text("Please update to take advantage of the latest features and bug fixes.")));
+        CONSOLE.sendMessage(Component.text("*", NamedTextColor.DARK_AQUA));
+        CONSOLE.sendMessage(Component.text("* ", NamedTextColor.DARK_AQUA)
+                .append(Component.text("Download from your preferred site:")));
+        CONSOLE.sendMessage(Component.text("*", NamedTextColor.DARK_AQUA)
+                .append(Component.text("     Hangar: https://hangar.papermc.io/HideTheMonkey/Pathinator")));
+        CONSOLE.sendMessage(Component.text("*", NamedTextColor.DARK_AQUA)
+                .append(Component.text("     Modrinth: https://modrinth.com/plugin/pathinator")));
+        CONSOLE.sendMessage(Component.text("*", NamedTextColor.DARK_AQUA)
+                .append(Component.text("     Spigot: https://www.spigotmc.org/resources/pathinator.118803")));
+        CONSOLE.sendMessage(Component.text("*", NamedTextColor.DARK_AQUA));
+        CONSOLE.sendMessage(Component.text("************************************************************************",
+                NamedTextColor.DARK_AQUA));
         CONSOLE.sendMessage("");
     }
 }

--- a/src/main/java/com/hidethemonkey/pathinator/helpers/StringHelper.java
+++ b/src/main/java/com/hidethemonkey/pathinator/helpers/StringHelper.java
@@ -30,21 +30,6 @@ import org.bukkit.Location;
 public class StringHelper {
 
     /**
-     * Standardize the format of user locale
-     * 
-     * @param locale
-     * @return
-     */
-    public static String formatLocale(String locale) {
-        String[] parts = locale.split("_");
-        if (parts.length == 2) {
-            // return the language and country in the format "language_COUNTRY"
-            return parts[0] + "_" + parts[1].toUpperCase();
-        }
-        return locale;
-    }
-
-    /**
      * Get the string representation of a location (for debugging)
      * 
      * @param location


### PR DESCRIPTION
Update dependencies: move from Spigotmc to Papermc API. (Includes official support for 1.21.4.)
Update CommandAPI to 9.7.0 and use `.thenNested`