### PR TITLE
Update Paper dependency and libraries to support 1.21.8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.hidethemonkey</groupId>
     <artifactId>Pathinator</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.3</version>
     <packaging>jar</packaging>
     <name>Pathinator</name>
 
@@ -29,14 +29,14 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.4-R0.1-SNAPSHOT</version>
+            <version>1.21.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-        <!-- https://commandapi.jorel.dev/latest.html -->
+        <!-- https://github.com/CommandAPI/CommandAPI/releases/latest -->
         <dependency>
             <groupId>dev.jorel</groupId>
             <artifactId>commandapi-bukkit-shade</artifactId>
-            <version>9.7.0</version>
+            <version>10.1.2</version>
         </dependency>
         <!-- https://bstats.org/getting-started/include-metrics -->
         <dependency>
@@ -48,18 +48,19 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20250107</version>
+            <version>20250517</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.maven/maven-artifact -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.9.9</version>
+            <version>3.9.11</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/net.kyori/adventure-api -->
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.18.0</version>
+            <version>4.24.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This pull request updates dependencies and project versioning in the `pom.xml` file to ensure compatibility with newer versions and improve functionality. The most important changes include updates to the project version, dependency versions, and comments for clarity.

### Updates to project version:
* Updated the project version from `1.4.1` to `1.4.3` in the `pom.xml` file.

### Dependency updates:
* Updated the `paper-api` dependency version from `1.21.4-R0.1-SNAPSHOT` to `1.21.8-R0.1-SNAPSHOT`.
* Updated the `commandapi-bukkit-shade` dependency version from `9.7.0` to `10.1.2`.
* Updated the `org.json` dependency version from `20250107` to `20250517`.
* Updated the `maven-artifact` dependency version from `3.9.9` to `3.9.11`.
* Updated the `adventure-api` dependency version from `4.18.0` to `4.24.0`.

### Improvements to comments:
* Replaced the comment for the `commandapi-bukkit-shade` dependency to point to its GitHub releases page instead of the previous URL.