### PR TITLE
Replace string-based GameMode comparisons with enum checks.

### DIFF
--- a/src/main/java/com/hidethemonkey/pathinator/commands/FollowCommands.java
+++ b/src/main/java/com/hidethemonkey/pathinator/commands/FollowCommands.java
@@ -66,7 +66,7 @@ public class FollowCommands extends PathCommands {
 
         // Check if the player is in a supported game mode
         if (!playerHelper.isInCreative()) {
-            playerHelper.msg("/" + PathCommands.FOLLOW + " does not work in " + playerHelper.getGameMode() + " mode.");
+            playerHelper.msg("/" + PathCommands.FOLLOW + " does not work in " + playerHelper.getPlayer().getGameMode().name() + " mode.");
             return;
         }
 

--- a/src/main/java/com/hidethemonkey/pathinator/commands/PathCommands.java
+++ b/src/main/java/com/hidethemonkey/pathinator/commands/PathCommands.java
@@ -196,7 +196,7 @@ public abstract class PathCommands {
     protected boolean modeCheck(PlayerHelper playerHelper) {
         // Check if the player is in the correct game mode
         if (playerHelper.isInAdventure() || playerHelper.isInSpectator()) {
-            playerHelper.msg("Pathinator does not work in " + playerHelper.getGameMode() + " mode.");
+            playerHelper.msg("Pathinator does not work in " + playerHelper.getPlayer().getGameMode().name() + " mode.");
             return false;
         }
         // Check if we're enabled in survival mode

--- a/src/main/java/com/hidethemonkey/pathinator/helpers/PlayerHelper.java
+++ b/src/main/java/com/hidethemonkey/pathinator/helpers/PlayerHelper.java
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.Tag;
@@ -63,50 +64,20 @@ public class PlayerHelper {
         return player;
     }
 
-    /**
-     * Get the player's game mode
-     * 
-     * @return
-     */
-    public String getGameMode() {
-        return player.getGameMode().name();
-    }
-
-    /**
-     * Return if the player is in survival mode
-     * 
-     * @return
-     */
     public boolean isInSurvival() {
-        return getGameMode().equals("SURVIVAL");
+        return player.getGameMode() == GameMode.SURVIVAL;
     }
 
-    /**
-     * Return if the player is in adventure mode
-     * 
-     * @return
-     */
     public boolean isInAdventure() {
-        return getGameMode().equals("ADVENTURE");
+        return player.getGameMode() == GameMode.ADVENTURE;
     }
 
-    /**
-     * Return if the player is in spectator mode
-     * 
-     * @return
-     */
     public boolean isInSpectator() {
-        return getGameMode().equals("SPECTATOR");
+        return player.getGameMode() == GameMode.SPECTATOR;
     }
 
-    /**
-     * Return if the player is in creative mode
-     * 
-     * @param block
-     * @return
-     */
     public boolean isInCreative() {
-        return getGameMode().equals("CREATIVE");
+        return player.getGameMode() == GameMode.CREATIVE;
     }
 
     /**


### PR DESCRIPTION
Use GameMode enum constants in isInSurvival/Adventure/Spectator/Creative() instead of string comparison. Remove getGameMode() string helper; update callers in PathCommands and FollowCommands to use player.getGameMode().name() directly.