### PR TITLE
Add per-command tool lookup cache to PlayerHelper.

### DIFF
--- a/src/main/java/com/hidethemonkey/pathinator/helpers/PlayerHelper.java
+++ b/src/main/java/com/hidethemonkey/pathinator/helpers/PlayerHelper.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -49,6 +50,7 @@ public class PlayerHelper {
 
     Player player;
     Pathinator plugin;
+    private final Map<String, ItemStack> toolCache = new HashMap<>();
 
     public PlayerHelper(Player player, Pathinator plugin) {
         this.player = player;
@@ -133,6 +135,10 @@ public class PlayerHelper {
             return null;
         }
 
+        if (toolCache.containsKey(type)) {
+            return toolCache.get(type);
+        }
+
         PlayerInventory inventory = player.getInventory();
         List<ItemStack> tools = new ArrayList<ItemStack>();
         for (ItemStack item : inventory.getContents()) {
@@ -140,6 +146,7 @@ public class PlayerHelper {
                 tools.add(item);
             }
         }
+        ItemStack result;
         if (!tools.isEmpty()) {
             // Sort tools by least amount of remaining durability
             Comparator<ItemStack> comp = (ItemStack a, ItemStack b) -> {
@@ -148,17 +155,19 @@ public class PlayerHelper {
                 return acomp - bcomp;
             };
             Collections.sort(tools, comp);
-
-            return tools.get(0);
+            result = tools.get(0);
+        } else {
+            // Player doesn't have a tool so pass back a wooden version, but with 0 amount.
+            // This is done so we know the material requires a tool but the player just
+            // doesn't have one.
+            Material fakeTool = Material.getMaterial("WOODEN_" + type);
+            if (fakeTool == null) {
+                fakeTool = material;
+            }
+            result = new ItemStack(fakeTool, 0);
         }
-        // Player doesn't have a tool so pass back a wooden version, but with 0 amount.
-        // This is done so we know the material requires a tool but the player just
-        // doesn't have one.
-        Material fakeTool = Material.getMaterial("WOODEN_" + type);
-        if (fakeTool == null) {
-            fakeTool = material;
-        }
-        return new ItemStack(fakeTool, 0);
+        toolCache.put(type, result);
+        return result;
     }
 
     /**


### PR DESCRIPTION
Cache getMineableTool() results by tool type so a 500-block path command scans inventory once per tool type instead of 500 times. Cache is scoped to the PlayerHelper instance, which is created fresh per command invocation.