### PR TITLE
bump dependencies and fix deprecated Paper API usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.8-R0.1-SNAPSHOT</version>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://github.com/CommandAPI/CommandAPI/releases/latest -->
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20250517</version>
+            <version>20251224</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.maven/maven-artifact -->
         <dependency>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.24.0</version>
+            <version>4.26.1</version>
         </dependency>
     </dependencies>
 
@@ -78,7 +78,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.2</version>
                     <configuration>
                         <minimizeJar>true</minimizeJar>
                         <createDependencyReducedPom>false</createDependencyReducedPom>
@@ -115,7 +115,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <archive>
                             <manifestEntries>

--- a/src/main/java/com/hidethemonkey/pathinator/commands/CommandRegistrar.java
+++ b/src/main/java/com/hidethemonkey/pathinator/commands/CommandRegistrar.java
@@ -8,6 +8,7 @@ import dev.jorel.commandapi.arguments.IntegerArgument;
 import dev.jorel.commandapi.arguments.LiteralArgument;
 import dev.jorel.commandapi.arguments.StringArgument;
 import dev.jorel.commandapi.executors.PlayerCommandExecutor;
+import net.kyori.adventure.text.Component;
 
 import com.hidethemonkey.pathinator.Pathinator;
 import com.hidethemonkey.pathinator.PathinatorConfig;
@@ -98,7 +99,7 @@ public class CommandRegistrar {
                         .withPermission("pathinator.admin")
                         .executesPlayer((PlayerCommandExecutor) (sender, args) -> {
                             plugin.reloadPlugin();
-                            sender.sendMessage("[" + plugin.getName() + "]: Config reloaded.");
+                            sender.sendMessage(Component.text("[" + plugin.getName() + "]: Config reloaded."));
                         }))
                 .register();
     }

--- a/src/main/java/com/hidethemonkey/pathinator/helpers/PlayerHelper.java
+++ b/src/main/java/com/hidethemonkey/pathinator/helpers/PlayerHelper.java
@@ -43,6 +43,7 @@ import org.bukkit.inventory.PlayerInventory;
 
 import com.hidethemonkey.pathinator.Pathinator;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -253,10 +254,10 @@ public class PlayerHelper {
 
     /**
      * Send a message to the player
-     * 
+     *
      * @param message
      */
     public void msg(String message) {
-        player.sendMessage("[" + plugin.getName() + "]: " + message);
+        player.sendMessage(Component.text("[" + plugin.getName() + "]: " + message));
     }
 }


### PR DESCRIPTION
## Summary

  - Bumped paper-api 1.21.8 → 1.21.11, adventure-api 4.24.0 → 4.26.1,
    org.json 20250517 → 20251224, maven-shade-plugin 3.6.0 → 3.6.2,
    maven-jar-plugin 3.4.2 → 3.5.0
  - commandapi-bukkit-shade stays at 10.1.2 — v11.2.0 released on GitHub
    but not yet published to Maven Central or PaperMC repo
  - Replaced deprecated player/sender.sendMessage(String) with Adventure
    Component.text() API in PlayerHelper.java and CommandRegistrar.java